### PR TITLE
react-gh-pages Link Fix

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -67,8 +67,8 @@ function App() {
           This website is deployed by borrowing the incredible efforts of the{" "}
           <Link
             description="react-gh-pages contributors"
-            url="https://github.com/gitname/react-gh-pages"
-          />{" "}
+            url="https://github.com/gitname/react-gh-pages/graphs/contributors"
+          />
           .
         </p>
       </header>

--- a/src/app/__tests__/__snapshots__/App-test.js.snap
+++ b/src/app/__tests__/__snapshots__/App-test.js.snap
@@ -169,11 +169,10 @@ exports[`renders to match snapshot 1`] = `
        
       <a
         className="App-link"
-        href="https://github.com/gitname/react-gh-pages"
+        href="https://github.com/gitname/react-gh-pages/graphs/contributors"
       >
         react-gh-pages contributors
       </a>
-       
       .
     </p>
   </header>


### PR DESCRIPTION
The credits link to the react-gh-pages project has been changed to a link of the contributors page for the project.