### PR TITLE
Remove <p/> Elements

### DIFF
--- a/.github/workflows/siteDeploy.yml
+++ b/.github/workflows/siteDeploy.yml
@@ -1,5 +1,5 @@
 # https://github.com/marketplace/actions/deploy-react-app-to-github-pages
-name: React app deployement
+name: React App Deployment
 
 on:
   push:
@@ -11,4 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Deploy react app to github pages
-        uses: tanwanimohit/deploy-react-to-ghpages@v1.0.1
+        # Use commit until v.1.0.2 is released: https://github.com/tanwanimohit/deploy-react-to-ghpages/issues/6
+        uses: tanwanimohit/deploy-react-to-ghpages@c3fd37aa52fe2c6365bd9cc35d88c912cae5e34f

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-site",
+  "name": "austin-site",
   "version": "0.1.0",
   "homepage": "https://atb-brown.github.io/austin",
   "private": true,
@@ -19,7 +19,6 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "build": "yarn siteBuild",
     "lint": "eslint src --ext .ts,.tsx",
     "prettyCheck": "prettier --check .",
     "prettyFix": "prettier --write .",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,16 +17,16 @@ function App() {
           style={{ display: "flex", alignItems: "flex-start", width: "100%" }}
         >
           <img src={logo} className="App-logo" alt="logo" />
-          <p>
+          <div>
             Austin&apos;s React website.
             <br />
             <Link
               description="(see the source code)"
               url="https://github.com/atb-brown/austin"
             />
-          </p>
+          </div>
         </div>
-        <p>
+        <div>
           <h3>Links</h3>
           <PortfolioLink
             description="GitHub"
@@ -57,8 +57,11 @@ function App() {
             issuerDescription="Scaled Agile, Inc."
             issuerUrl="https://scaledagile.com/"
           />
-        </p>
-        <p className="App-soft-text" style={{ fontSize: 20, paddingLeft: 50 }}>
+        </div>
+        <div
+          className="App-soft-text"
+          style={{ fontSize: 20, paddingLeft: 50 }}
+        >
           <Link
             description="Initialized"
             url="https://github.com/atb-brown/austin/commit/5c8514a96194e6271d4e8e7f234499ee4e95ab3d"
@@ -68,15 +71,15 @@ function App() {
             description="create-react-app"
             url="https://create-react-app.dev/"
           />{" "}
-        </p>
-        <p className="App-soft-text" style={{ fontSize: 20 }}>
+        </div>
+        <div className="App-soft-text" style={{ fontSize: 20 }}>
           This website is deployed by borrowing the incredible efforts of the{" "}
           <Link
             description="react-gh-pages contributors"
             url="https://github.com/gitname/react-gh-pages/graphs/contributors"
           />
           .
-        </p>
+        </div>
       </header>
     </div>
   );

--- a/src/app/__tests__/__snapshots__/App-test.js.snap
+++ b/src/app/__tests__/__snapshots__/App-test.js.snap
@@ -21,7 +21,7 @@ exports[`renders to match snapshot 1`] = `
         className="App-logo"
         src={{}}
       />
-      <p>
+      <div>
         Austin's React website.
         <br />
         <a
@@ -30,9 +30,9 @@ exports[`renders to match snapshot 1`] = `
         >
           (see the source code)
         </a>
-      </p>
+      </div>
     </div>
-    <p>
+    <div>
       <h3>
         Links
       </h3>
@@ -130,8 +130,8 @@ exports[`renders to match snapshot 1`] = `
         </div>
         <br />
       </div>
-    </p>
-    <p
+    </div>
+    <div
       className="App-soft-text"
       style={
         {
@@ -156,8 +156,8 @@ exports[`renders to match snapshot 1`] = `
         create-react-app
       </a>
        
-    </p>
-    <p
+    </div>
+    <div
       className="App-soft-text"
       style={
         {
@@ -174,7 +174,7 @@ exports[`renders to match snapshot 1`] = `
         react-gh-pages contributors
       </a>
       .
-    </p>
+    </div>
   </header>
 </div>
 `;

--- a/src/component/PortfolioLink.tsx
+++ b/src/component/PortfolioLink.tsx
@@ -35,7 +35,6 @@ export default function PortfolioLink(props: LinkProps) {
  * @return {ReactElement} The portfolio link component.
  */
 function LinkWithoutIssuer(props: LinkProps) {
-  // TODO: it's a bad idea to have <div/> elements that are children of <p/> elements
   return (
     <div>
       <div>{props.description}</div>


### PR DESCRIPTION
I had a few <div/> elements that were nested within <p/> elements. That is apparently discouraged:
https://stackoverflow.com/questions/41928567/div-cannot-appear-as-a-descendant-of-p

In my use cases, I think the <div/> elements are necessary whereas the <p/> elements are not, so I'm getting rid of the paragraphs and keeping the divs instead of the other way around. I'm going to see if there are jsx linters that are available through npm.

I also did a little bit of configuration in the siteDeploy action due to some updates to the action I've been using.