### PR TITLE
Introduce useWindowDimensions Hook

### DIFF
--- a/src/hook/dimension/__tests__/TestComponentUseWindowDimension.tsx
+++ b/src/hook/dimension/__tests__/TestComponentUseWindowDimension.tsx
@@ -1,0 +1,13 @@
+import useWindowDimensions from "../useWindowDimensions";
+import React from "react";
+
+/**
+ * This component is intended for test use only. It just displays the window's width and height.
+ *
+ * @return {ReactElement}
+ */
+export default function TestComponentUseWindowDimension() {
+  const { height, width } = useWindowDimensions();
+
+  return <div>{"width: " + width + " / height: " + height}</div>;
+}

--- a/src/hook/dimension/__tests__/__snapshots__/useWindowDimensions-test.js.snap
+++ b/src/hook/dimension/__tests__/__snapshots__/useWindowDimensions-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test window width and height. 1`] = `
+<DocumentFragment>
+  <div>
+    width: 1000 / height: 800
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Test window width and height. 2`] = `
+<DocumentFragment>
+  <div>
+    width: 500 / height: 400
+  </div>
+</DocumentFragment>
+`;

--- a/src/hook/dimension/__tests__/useWindowDimensions-test.js
+++ b/src/hook/dimension/__tests__/useWindowDimensions-test.js
@@ -1,0 +1,29 @@
+import TestComponentUseWindowDimension from "./TestComponentUseWindowDimension";
+import { render } from "@testing-library/react";
+
+it("Test window width and height.", () => {
+  // Set the size
+  setScreenSize(1000, 800);
+  var { asFragment } = render(<TestComponentUseWindowDimension />);
+
+  expect(asFragment()).toMatchSnapshot();
+
+  // Set a new size and re-render
+  setScreenSize(500, 400);
+  var { asFragment } = render(<TestComponentUseWindowDimension />);
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+function setScreenSize(width, height) {
+  setProp("innerWidth", width);
+  setProp("innerHeight", height);
+}
+
+function setProp(propName, value) {
+  Object.defineProperty(window, propName, {
+    writable: true,
+    configurable: true,
+    value: value,
+  });
+}

--- a/src/hook/dimension/useWindowDimensions.ts
+++ b/src/hook/dimension/useWindowDimensions.ts
@@ -1,0 +1,38 @@
+// https://stackoverflow.com/questions/36862334/get-viewport-window-height-in-reactjs
+// https://pastebin.com/cCycfwaL
+import { useState, useEffect } from "react";
+
+type WindowDimensions = {
+  width: number;
+  height: number;
+};
+
+const getWindowDimensions = (): WindowDimensions => {
+  const { innerWidth, innerHeight } = window;
+
+  return {
+    width: innerWidth,
+    height: innerHeight,
+  };
+};
+
+const useWindowDimensions = (): WindowDimensions => {
+  const [windowDimensions, setWindowDimensions] = useState<WindowDimensions>({
+    width: 0,
+    height: 0,
+  });
+
+  const handleResize = () => {
+    setWindowDimensions(getWindowDimensions());
+  };
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+};
+
+export default useWindowDimensions;


### PR DESCRIPTION
This commit introduces the useWindowDimensions hook, which can be used to allow components to reference the width and height of the rendering window.