### PR TITLE
Stats Ribbon is Hidden with Click

### DIFF
--- a/src/app/__tests__/__snapshots__/App-test.js.snap
+++ b/src/app/__tests__/__snapshots__/App-test.js.snap
@@ -10,13 +10,14 @@ exports[`renders to match snapshot 1`] = `
       class="App-header"
     >
       <div
-        style="width: 99%; border-radius: 10px; background-color: rebeccapurple;"
+        data-testid="stats-ribbon"
+        style="height: 5vh; display: flex; width: 97%; align-items: center; flex-direction: row-reverse; background-color: rebeccapurple; border-radius: 10px;"
       >
         <div
-          style="display: flex; width: 97%; height: 100%; flex-direction: row-reverse;"
+          style="display: flex; height: 100%; width: 10%; align-items: center;"
         >
           <div
-            style="font-size: 10.24px; display: flex; flex-direction: column;"
+            style="font-size: 10px; display: flex; flex-direction: column;"
           >
             <div>
               Window Size

--- a/src/component/widget/statistic/Stats.tsx
+++ b/src/component/widget/statistic/Stats.tsx
@@ -1,5 +1,5 @@
 import WindowSize from "./WindowSize";
-import React from "react";
+import React, { useCallback } from "react";
 
 /**
  * A "ribbon" component that displays diagnostics/statistics.
@@ -7,25 +7,69 @@ import React from "react";
  * @return {ReactElement} React Component
  */
 export default function Stats() {
+  const [showResults, setShowResults] = React.useState(true);
+  const onClick = useCallback(() => {
+    setShowResults(!showResults);
+  }, [showResults, setShowResults]);
   const widthPrcnt = "97%";
-  return (
-    <div
-      style={{
-        width: "99%",
-        borderRadius: 10,
-        backgroundColor: "rebeccapurple",
-      }}
-    >
+
+  if (showResults) {
+    return (
+      <div
+        data-testid="stats-ribbon"
+        onClick={onClick}
+        style={{
+          height: "5vh",
+          display: "flex",
+          width: widthPrcnt,
+          alignItems: "center",
+          flexDirection: "row-reverse",
+          backgroundColor: "rebeccapurple",
+          borderRadius: 10,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            height: "100%",
+            width: "10%",
+            alignItems: "center",
+          }}
+        >
+          <WindowSize />
+        </div>
+      </div>
+    );
+  } else {
+    const leftArrow = "◀";
+    // TODO: Put the hidden stats ribbon in its own component file.
+    return (
       <div
         style={{
           display: "flex",
-          width: widthPrcnt,
-          height: "100%",
+          width: "96%",
+          height: "5vh",
+          borderRadius: 10,
           flexDirection: "row-reverse",
         }}
       >
-        <WindowSize />
+        <div
+          data-testid="stats-ribbon-hidden"
+          onClick={onClick}
+          style={{
+            display: "flex",
+            aspectRatio: 1,
+            height: "100%",
+            flexDirection: "row-reverse",
+            backgroundColor: "rebeccapurple",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: 10,
+          }}
+        >
+          {leftArrow}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }

--- a/src/component/widget/statistic/WindowSize.tsx
+++ b/src/component/widget/statistic/WindowSize.tsx
@@ -9,7 +9,7 @@ import React from "react";
 export default function WindowSize() {
   const { width, height } = useWindowDimensions();
   const title = "Window Size";
-  const fontSize = Math.max(10, width / 100);
+  const fontSize = Math.max(10, width / 130);
   return (
     <div
       style={{ fontSize: fontSize, display: "flex", flexDirection: "column" }}

--- a/src/component/widget/statistic/__tests__/Stats-test.js
+++ b/src/component/widget/statistic/__tests__/Stats-test.js
@@ -1,8 +1,37 @@
 import Stats from "../Stats";
-import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { screen, render, fireEvent } from "@testing-library/react";
 
-it("renders to match snapshot", () => {
+it("initial view renders to match snapshot", () => {
   const { asFragment } = render(<Stats />);
 
   expect(asFragment()).toMatchSnapshot();
+});
+
+it("hidden view renders to match snapshot", () => {
+  const { asFragment } = render(<Stats />);
+
+  const statsRibbon = screen.getByTestId("stats-ribbon");
+  fireEvent.click(statsRibbon);
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+it("click toggles the ribbon", () => {
+  render(<Stats />);
+
+  // Initial state, full ribbon is displayed.
+  const statsRibbon = screen.getByTestId("stats-ribbon");
+  expect(statsRibbon).toBeDefined();
+
+  // After clicking, ribbon should be hidden.
+  fireEvent.click(statsRibbon);
+  const hiddenStatsRibbon = screen.getByTestId("stats-ribbon-hidden");
+  expect(hiddenStatsRibbon).toBeDefined();
+  expect(screen.queryByTestId("stats-ribbon")).toBeNull();
+
+  // After clicking again, ribbon should be displayed again.
+  fireEvent.click(hiddenStatsRibbon);
+  expect(screen.getByTestId("stats-ribbon")).toBeDefined();
+  expect(screen.queryByTestId("stats-ribbon-hidden")).toBeNull();
 });

--- a/src/component/widget/statistic/__tests__/__snapshots__/Stats-test.js.snap
+++ b/src/component/widget/statistic/__tests__/__snapshots__/Stats-test.js.snap
@@ -1,15 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders to match snapshot 1`] = `
+exports[`hidden view renders to match snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="width: 99%; border-radius: 10px; background-color: rebeccapurple;"
+    style="height: 5vh; display: flex; width: 96%; flex-direction: row-reverse; border-radius: 10px;"
   >
     <div
-      style="display: flex; width: 97%; height: 100%; flex-direction: row-reverse;"
+      data-testid="stats-ribbon-hidden"
+      style="display: flex; height: 100%; align-items: center; flex-direction: row-reverse; background-color: rebeccapurple; justify-content: center; border-radius: 10px;"
+    >
+      ◀
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`initial view renders to match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="stats-ribbon"
+    style="height: 5vh; display: flex; width: 97%; align-items: center; flex-direction: row-reverse; background-color: rebeccapurple; border-radius: 10px;"
+  >
+    <div
+      style="display: flex; height: 100%; width: 10%; align-items: center;"
     >
       <div
-        style="font-size: 10.24px; display: flex; flex-direction: column;"
+        style="font-size: 10px; display: flex; flex-direction: column;"
       >
         <div>
           Window Size

--- a/src/component/widget/statistic/__tests__/__snapshots__/WindowSize-test.js.snap
+++ b/src/component/widget/statistic/__tests__/__snapshots__/WindowSize-test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders to match snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="font-size: 10.24px; display: flex; flex-direction: column;"
+    style="font-size: 10px; display: flex; flex-direction: column;"
   >
     <div>
       Window Size


### PR DESCRIPTION
Previously the stats ribbon at the top of the page was static and always visible; now the user can click the ribbon to hide it and then click the hidden tab to make it reappear.