### PR TITLE
disable-text-selection CSS Class

### DIFF
--- a/src/app/AppTitle.tsx
+++ b/src/app/AppTitle.tsx
@@ -1,3 +1,4 @@
+import "../common.css";
 import Link from "../component/Link";
 import logo from "../logo.svg";
 import React from "react";
@@ -12,7 +13,7 @@ export default function AppTitle() {
 
   return (
     <div style={{ display: "flex", width: "100%" }}>
-      <img alt="logo" className="App-logo" src={logo} />
+      <img alt="logo" className="App-logo disable-text-selection" src={logo} />
       <div>
         {title}
         <br />

--- a/src/app/__tests__/__snapshots__/App-test.js.snap
+++ b/src/app/__tests__/__snapshots__/App-test.js.snap
@@ -34,7 +34,7 @@ exports[`renders to match snapshot 1`] = `
       >
         <img
           alt="logo"
-          class="App-logo"
+          class="App-logo disable-text-selection"
           src="[object Object]"
         />
         <div>
@@ -164,6 +164,7 @@ exports[`renders to match snapshot 1`] = `
           style="width: 100%; flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;"
         >
           <div
+            class="disable-text-selection"
             data-testid="counter"
             style="display: flex; font-size: 20px; background-color: steelblue; align-items: center; justify-content: center; width: 25%; height: 60px; border-radius: 10px;"
             title="This component counts the number of times it has been clicked. It's an exercise in handling clicks and component state!"

--- a/src/app/__tests__/__snapshots__/AppBody-test.js.snap
+++ b/src/app/__tests__/__snapshots__/AppBody-test.js.snap
@@ -139,6 +139,7 @@ exports[`renders to match snapshot 1`] = `
     }
   >
     <div
+      className="disable-text-selection"
       data-testid="counter"
       onClick={[Function]}
       style={

--- a/src/app/__tests__/__snapshots__/AppTitle-test.js.snap
+++ b/src/app/__tests__/__snapshots__/AppTitle-test.js.snap
@@ -11,7 +11,7 @@ exports[`renders to match snapshot 1`] = `
 >
   <img
     alt="logo"
-    className="App-logo"
+    className="App-logo disable-text-selection"
     src={{}}
   />
   <div>

--- a/src/app/__tests__/__snapshots__/AppWidgets-test.js.snap
+++ b/src/app/__tests__/__snapshots__/AppWidgets-test.js.snap
@@ -14,6 +14,7 @@ exports[`renders to match snapshot 1`] = `
   }
 >
   <div
+    className="disable-text-selection"
     data-testid="counter"
     onClick={[Function]}
     style={

--- a/src/common.css
+++ b/src/common.css
@@ -1,0 +1,7 @@
+.disable-text-selection {
+  /* https://reactgo.com/react-disable-text-selection/ */
+  -moz-user-select: none; /* firefox */
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE*/
+  user-select: none; /* Standard syntax */
+}

--- a/src/component/widget/count/Counter.tsx
+++ b/src/component/widget/count/Counter.tsx
@@ -1,3 +1,4 @@
+import "../../../common.css";
 import React, { useCallback } from "react";
 
 /**
@@ -13,6 +14,7 @@ export default function Counter() {
 
   return (
     <div
+      className="disable-text-selection"
       data-testid="counter"
       onClick={onClick}
       style={{

--- a/src/component/widget/count/__tests__/__snapshots__/Counter-test.js.snap
+++ b/src/component/widget/count/__tests__/__snapshots__/Counter-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`renders to match snapshot 1`] = `
 <div
+  className="disable-text-selection"
   data-testid="counter"
   onClick={[Function]}
   style={

--- a/src/component/widget/statistic/HiddenStats.tsx
+++ b/src/component/widget/statistic/HiddenStats.tsx
@@ -1,3 +1,4 @@
+import "../../../common.css";
 import "./Stats.css";
 import React from "react";
 
@@ -10,7 +11,7 @@ import React from "react";
 export default function Stats({ onClick }: HiddenStatsProps) {
   const leftArrow = "◀";
   return (
-    <div className="Stats Stats-Container">
+    <div className="Stats Stats-Container disable-text-selection">
       <div
         className="Stats Stats-Visual"
         data-testid="stats-ribbon-hidden"

--- a/src/component/widget/statistic/__tests__/__snapshots__/HiddenStats-test.js.snap
+++ b/src/component/widget/statistic/__tests__/__snapshots__/HiddenStats-test.js.snap
@@ -3,7 +3,7 @@
 exports[`initial view renders to match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="Stats Stats-Container"
+    class="Stats Stats-Container disable-text-selection"
   >
     <div
       class="Stats Stats-Visual"
@@ -19,7 +19,7 @@ exports[`initial view renders to match snapshot 1`] = `
 exports[`onClick is invoked when component is clicked 1`] = `
 <DocumentFragment>
   <div
-    class="Stats Stats-Container"
+    class="Stats Stats-Container disable-text-selection"
   >
     <div
       class="Stats Stats-Visual"

--- a/src/component/widget/statistic/__tests__/__snapshots__/Stats-test.js.snap
+++ b/src/component/widget/statistic/__tests__/__snapshots__/Stats-test.js.snap
@@ -3,7 +3,7 @@
 exports[`hidden view renders to match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="Stats Stats-Container"
+    class="Stats Stats-Container disable-text-selection"
   >
     <div
       class="Stats Stats-Visual"


### PR DESCRIPTION
This commit adds a common.css stylesheet with a disable-text-selection class which will allow components to disable user text selection.