### PR TITLE
Introduce ProviderRegistry Class

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,19 +2,16 @@ import Stats from "../component/widget/statistic/Stats";
 import useWindowDimensions from "../hook/dimension/useWindowDimensions";
 import "./App.css";
 import AppAcknowledgements from "./AppAcknowledgements";
-import AppBody, { AppBodyProviders } from "./AppBody";
+import AppBody from "./AppBody";
 import AppTitle from "./AppTitle";
 import React from "react";
-
-// TODO: Come up with a more elegant solution for injection.
-export type AppProviders = AppBodyProviders; // ... & OtherComponentProviders & AnotherComponentProviders; <- union with other providers, if the need arises.
 
 /**
  * The main component for the site application.
  *
  * @return {ReactElement} React Component
  */
-function App({ guestProvider }: AppProviders) {
+function App() {
   const { width, height } = useWindowDimensions();
   return (
     <div
@@ -29,7 +26,7 @@ function App({ guestProvider }: AppProviders) {
       <header className="App-header">
         <Stats />
         <AppTitle />
-        <AppBody guestProvider={guestProvider} />
+        <AppBody />
         <AppAcknowledgements />
       </header>
     </div>

--- a/src/app/AppBody.tsx
+++ b/src/app/AppBody.tsx
@@ -1,23 +1,20 @@
 import AppLinks from "./AppLinks";
-import AppWidgets, { AppWidgetsProviders } from "./AppWidgets";
+import AppWidgets from "./AppWidgets";
 import React from "react";
-
-// TODO: Come up with a more elegant solution for injection.
-export type AppBodyProviders = AppWidgetsProviders; // ... & OtherComponentProviders & AnotherComponentProviders; <- union with other providers, if the need arises.
 
 /**
  * The primary body of the site that I want prominently displayed on my site.
  *
  * @return {ReactElement}
  */
-export default function AppBody({ guestProvider }: AppBodyProviders) {
+export default function AppBody() {
   return (
     <div style={{ display: "flex", width: "100%" }}>
       <div style={{ display: "flex", flex: 1 }}>
         <AppLinks />
       </div>
       <div style={{ display: "flex", flex: 3 }}>
-        <AppWidgets guestProvider={guestProvider} />
+        <AppWidgets />
       </div>
     </div>
   );

--- a/src/app/AppWidgets.tsx
+++ b/src/app/AppWidgets.tsx
@@ -1,18 +1,13 @@
 import Counter from "../component/widget/count/Counter";
-import GuestBook, {
-  GuestBookProviders,
-} from "../component/widget/guestBook/GuestBook";
+import GuestBook from "../component/widget/guestBook/GuestBook";
 import React from "react";
-
-// TODO: Come up with a more elegant solution for injection.
-export type AppWidgetsProviders = GuestBookProviders; // ... & OtherComponentProviders & AnotherComponentProviders; <- union with other providers, if the need arises.
 
 /**
  * This component holds widgets with which I'm experimenting with React.
  *
  * @return {ReactElement}
  */
-export default function AppWidgets({ guestProvider }: AppWidgetsProviders) {
+export default function AppWidgets() {
   return (
     <div
       style={{
@@ -47,7 +42,7 @@ export default function AppWidgets({ guestProvider }: AppWidgetsProviders) {
           justifyContent: "center",
         }}
       >
-        <GuestBook guestProvider={guestProvider} />
+        <GuestBook />
       </div>
     </div>
   );

--- a/src/app/__tests__/App-test.js
+++ b/src/app/__tests__/App-test.js
@@ -1,14 +1,13 @@
-import { useGuestBookInfoMockProvider } from "../../test/mock/hook/mockUseGuestBookInfo";
+import { wait as guestBook } from "../../test/component/GuestBookTestUtils";
+import { registerMockProvider as mockGuestBookProvider } from "../../test/mock/hook/mockUseGuestBookInfo";
 import App from "../App";
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 it("renders to match snapshot", async () => {
-  const renderResult = render(
-    <App guestProvider={useGuestBookInfoMockProvider()} />
-  );
+  mockGuestBookProvider();
+  const renderResult = render(<App />);
 
-  // Wait for the underlying promise to resolve.
-  await waitFor(() => renderResult.getByText("info loaded"));
+  await guestBook(renderResult);
 
   expect(renderResult.asFragment()).toMatchSnapshot();
 });

--- a/src/app/__tests__/AppBody-test.js
+++ b/src/app/__tests__/AppBody-test.js
@@ -1,15 +1,13 @@
-import { useGuestBookInfoMockProvider } from "../../test/mock/hook/mockUseGuestBookInfo";
+import { wait as guestBook } from "../../test/component/GuestBookTestUtils";
+import { registerMockProvider as mockGuestBookProvider } from "../../test/mock/hook/mockUseGuestBookInfo";
 import AppBody from "../AppBody";
-// import renderer from "react-test-renderer";
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 it("renders to match snapshot", async () => {
-  const renderResult = render(
-    <AppBody guestProvider={useGuestBookInfoMockProvider()} />
-  );
+  mockGuestBookProvider();
+  const renderResult = render(<AppBody />);
 
-  // Wait for the underlying promise to resolve.
-  await waitFor(() => renderResult.getByText("info loaded"));
+  await guestBook(renderResult);
 
   expect(renderResult.asFragment()).toMatchSnapshot();
 });

--- a/src/app/__tests__/AppWidgets-test.js
+++ b/src/app/__tests__/AppWidgets-test.js
@@ -1,15 +1,13 @@
-// import renderer from "react-test-renderer";
-import { useGuestBookInfoMockProvider } from "../../test/mock/hook/mockUseGuestBookInfo";
+import { wait as guestBook } from "../../test/component/GuestBookTestUtils";
+import { registerMockProvider as mockGuestBookProvider } from "../../test/mock/hook/mockUseGuestBookInfo";
 import AppWidgets from "../AppWidgets";
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 it("renders to match snapshot", async () => {
-  const renderResult = render(
-    <AppWidgets guestProvider={useGuestBookInfoMockProvider()} />
-  );
+  mockGuestBookProvider();
+  const renderResult = render(<AppWidgets />);
 
-  // Wait for the underlying promise to resolve.
-  await waitFor(() => renderResult.getByText("info loaded"));
+  await guestBook(renderResult);
 
   expect(renderResult.asFragment()).toMatchSnapshot();
 });

--- a/src/component/widget/guestBook/GuestBook.tsx
+++ b/src/component/widget/guestBook/GuestBook.tsx
@@ -1,7 +1,5 @@
 import { GuestInfo } from "../../../hook/guests/guestBookInfo";
-import useGuestBookInfo, {
-  Provider,
-} from "../../../hook/guests/useGuestBookInfo";
+import useGuestBookInfo from "../../../hook/guests/useGuestBookInfo";
 import GuestEntry, { guestEntryGap } from "./GuestEntry";
 import React from "react";
 
@@ -23,18 +21,13 @@ function mapComponent(guestInfo: GuestInfo) {
   );
 }
 
-// TODO: Come up with a more elegant solution for injection.
-export type GuestBookProviders = {
-  readonly guestProvider?: Provider | undefined | null;
-};
-
 /**
  * This component is a "guest book" that displays people that have visited my website and have signed the guest book.
  *
  * @return {ReactElement}
  */
-export default function GuestBook({ guestProvider }: GuestBookProviders) {
-  const { guests } = useGuestBookInfo(guestProvider);
+export default function GuestBook() {
+  const { guests } = useGuestBookInfo();
 
   // TODO: Add a button to "sign my guest book"
   // TODO: Add logic so that only the top row and the bottom row have rounded corners.

--- a/src/component/widget/guestBook/__tests__/GuestBook-test.js
+++ b/src/component/widget/guestBook/__tests__/GuestBook-test.js
@@ -1,37 +1,32 @@
-import { useGuestBookInfoMockProvider } from "../../../../test/mock/hook/mockUseGuestBookInfo";
+import { wait as guestBook } from "../../../../test/component/GuestBookTestUtils";
+import { registerMockProvider } from "../../../../test/mock/hook/mockUseGuestBookInfo";
 import GuestBook from "../GuestBook";
 import "@testing-library/jest-dom";
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 it("render single guest info to match snapshot", async () => {
-  const renderResult = render(
-    <GuestBook guestProvider={useGuestBookInfoMockProvider()} />
-  );
+  registerMockProvider();
+  const renderResult = render(<GuestBook />);
 
-  // Wait for the underlying promise to resolve.
-  await waitFor(() => renderResult.getByText("info loaded"));
+  await guestBook(renderResult);
 
   expect(renderResult.asFragment()).toMatchSnapshot();
 });
 
 it("render multiple guest info to match snapshot", async () => {
-  const renderResult = render(
-    <GuestBook guestProvider={useGuestBookInfoMockProvider(7)} />
-  );
+  registerMockProvider(7);
+  const renderResult = render(<GuestBook />);
 
-  // Wait for the underlying promise to resolve.
-  await waitFor(() => renderResult.getByText("info loaded"));
+  await guestBook(renderResult);
 
   expect(renderResult.asFragment()).toMatchSnapshot();
 });
 
 it("render NO guest info to match snapshot", async () => {
-  const renderResult = render(
-    <GuestBook guestProvider={useGuestBookInfoMockProvider(0)} />
-  );
+  registerMockProvider(0);
+  const renderResult = render(<GuestBook />);
 
-  // Wait for the underlying promise to resolve.
-  await waitFor(() => renderResult.getByTestId("guest-book"));
+  await guestBook(renderResult);
 
   expect(renderResult.asFragment()).toMatchSnapshot();
 });

--- a/src/hook/guests/__tests__/TestComponentUseGuestBookInfo.tsx
+++ b/src/hook/guests/__tests__/TestComponentUseGuestBookInfo.tsx
@@ -1,20 +1,13 @@
-import useGuestBookInfo, { Provider } from "../useGuestBookInfo";
+import useGuestBookInfo from "../useGuestBookInfo";
 import React from "react";
-
-type CompProps = {
-  readonly provider: Provider;
-};
 
 /**
  * This component is intended for test use only. It's just used to test the useGuestBookInfo hook.
  *
  * @return {ReactElement}
  */
-export default function TestComponentUseWindowDimension({
-  provider,
-}: CompProps) {
-  // If needed, remove the provider parameter to test the real implementation.
-  const { guests } = useGuestBookInfo(provider);
+export default function TestComponentUseWindowDimension() {
+  const { guests } = useGuestBookInfo();
 
   return (
     <div>

--- a/src/hook/guests/__tests__/useGuestBookInfo-test.js
+++ b/src/hook/guests/__tests__/useGuestBookInfo-test.js
@@ -1,11 +1,10 @@
-import { useGuestBookInfoMockProvider } from "../../../test/mock/hook/mockUseGuestBookInfo";
+import { registerMockProvider } from "../../../test/mock/hook/mockUseGuestBookInfo";
 import TestComponentUseGuestBookInfo from "./TestComponentUseGuestBookInfo";
 import { render, waitFor } from "@testing-library/react";
 
 it("Basic Render", async () => {
-  const renderResult = render(
-    <TestComponentUseGuestBookInfo provider={useGuestBookInfoMockProvider()} />
-  );
+  registerMockProvider();
+  const renderResult = render(<TestComponentUseGuestBookInfo />);
   const fragment = renderResult.asFragment;
 
   // Wait for the underlying promise to resolve.

--- a/src/hook/guests/useGuestBookInfo.ts
+++ b/src/hook/guests/useGuestBookInfo.ts
@@ -1,35 +1,26 @@
+import Providers, { ProviderKey } from "../provide/ProviderRegistry";
 import { GuestBookInfo } from "./guestBookInfo";
 import retrieveGuestBookInfo from "./retrieveGuestBookInfo";
 import { useState, useEffect } from "react";
 
-export type Provider = () => Promise<GuestBookInfo>;
-
-/**
- * TODO: Come up with a more elegant solution for injection.
- * The real implementation. No logic should go here; any necessary logic should be put in testable elements.
- *
- * @return {Provider}
- */
-const providerImpl: Provider = () => {
-  return retrieveGuestBookInfo();
-};
-
 /**
  * This hook will allow components to access information from the guest book.
  *
- * @param {GuestBookInfo} provider The provider of the data. Optional. Should not be provided except for testing.
  * @return {GuestBookInfo}
  */
-const useGuestBookInfo = (provider: Provider | null = null): GuestBookInfo => {
+const useGuestBookInfo = (): GuestBookInfo => {
   const [guestBookInfo, setGuestBookInfo] = useState<GuestBookInfo>({
     guests: [],
   });
 
-  const prov: Provider = provider ? provider : providerImpl;
+  const provider = Providers.get<() => Promise<GuestBookInfo>>(
+    ProviderKey.useGuestBookInfo,
+    retrieveGuestBookInfo
+  );
 
   useEffect(() => {
-    prov().then((d) => setGuestBookInfo(d));
-  }, [prov]);
+    provider().then((d) => setGuestBookInfo(d));
+  }, [provider]);
 
   return guestBookInfo;
 };

--- a/src/hook/provide/ProviderRegistry.ts
+++ b/src/hook/provide/ProviderRegistry.ts
@@ -1,0 +1,57 @@
+type Provider = () => unknown;
+
+/**
+ * This class provides a simple method of dependency injection.
+ *
+ * https://stackoverflow.com/questions/130794/what-is-dependency-injection
+ *
+ * We want to use dependency injection so that we can write unit tests that do not
+ * rely (depend) on implementations that make testing difficult or unreliable.
+ */
+export default abstract class ProviderRegistry {
+  private static readonly registry: Map<ProviderKey, Provider> = new Map();
+
+  /**
+   * Register a provider; this will override the real implementation of services that use this class the check for registered providers.
+   *
+   * This function should NOT be used/called in any deployed code; this should only be used for testing.
+   *
+   * TODO: Create an eslint rule to ensure this is not called in deployed code. https://eslint.org/docs/latest/extend/custom-rule-tutorial
+   *
+   * @param {ProviderKey} providerKey The unique key of the provider that is being registered/injected.
+   * @param {Provider} providerImpl The actual implementation that is to be injected.
+   */
+  public static register(providerKey: ProviderKey, providerImpl: Provider) {
+    ProviderRegistry.registry.set(providerKey, providerImpl);
+  }
+
+  /**
+   * Get the registered provider. If no provider has been registered, the real implementation will be used.
+   *
+   * @param {ProviderKey} providerKey The unique key of the provider that is being registered/injected.
+   * @param {Provider} realProvider The real implementation that will be used if an alternative provider has not been registered.
+   *
+   * @return {Provider}
+   */
+  public static get<Provider>(
+    providerKey: ProviderKey,
+    realProvider: Provider
+  ): Provider {
+    return (
+      ProviderRegistry.registry.has(providerKey)
+        ? ProviderRegistry.registry.get(providerKey)
+        : realProvider
+    ) as Provider;
+  }
+}
+
+/**
+ * All of the possible implementations that might need alternative provider implementations
+ * for testing.
+ */
+export enum ProviderKey {
+  /** A react hook for retrieving guest book info. Normally relies
+   * on an HTTP call, which is a dependency we do not want in our testing.
+   */
+  useGuestBookInfo,
+}

--- a/src/hook/provide/__tests__/ProviderRegistry-test.js
+++ b/src/hook/provide/__tests__/ProviderRegistry-test.js
@@ -1,0 +1,18 @@
+import ProviderRegistry from "../ProviderRegistry";
+
+const mocked = "mocked";
+const notMocked = "not mocked";
+const fakeProviderKey = "useFakeProviderKey";
+const realProviderImpl = () => notMocked;
+
+it("Alternative Provider Not Registered", () => {
+  const provider = ProviderRegistry.get(fakeProviderKey, realProviderImpl);
+  expect(provider()).toBe(notMocked);
+});
+
+it("Alternative Provider Is Registered", () => {
+  // Normally, we need to use the TypeScript enum as a key, but JavaScript doesn't care.
+  ProviderRegistry.register(fakeProviderKey, () => mocked);
+  const provider = ProviderRegistry.get(fakeProviderKey, realProviderImpl);
+  expect(provider()).toBe(mocked);
+});

--- a/src/test/component/GuestBookTestUtils.js
+++ b/src/test/component/GuestBookTestUtils.js
@@ -1,0 +1,10 @@
+import { waitFor } from "@testing-library/react";
+
+/**
+ * Wait for a guest book component to have been rendered.
+ *
+ * @param {RenderResult} renderResult
+ */
+export async function wait(renderResult) {
+  await waitFor(() => renderResult.getByTestId("guest-book"));
+}

--- a/src/test/mock/hook/mockUseGuestBookInfo.js
+++ b/src/test/mock/hook/mockUseGuestBookInfo.js
@@ -1,10 +1,14 @@
+import ProviderRegistry, {
+  ProviderKey,
+} from "../../../hook/provide/ProviderRegistry";
+
 /**
  * Create a mocked implementation of a "GuestInfo" provider.
  *
  * @param {number} numOfGuestInfoEntries The number of "GuestInfo" objects that will be returned by the provider.
  * @return {Promise<GuestBook>}
  */
-export function useGuestBookInfoMockProvider(numOfGuestInfoEntries = 1) {
+function useGuestBookInfoMockProvider(numOfGuestInfoEntries = 1) {
   const guestBook = { guests: [] };
   for (let entryIndex = 0; entryIndex < numOfGuestInfoEntries; entryIndex++) {
     if (entryIndex === 0) {
@@ -28,4 +32,17 @@ export function useGuestBookInfoMockProvider(numOfGuestInfoEntries = 1) {
     new Promise((resolve) => {
       resolve(guestBook);
     });
+}
+
+/**
+ * Register/inject a provider that will be used in place of implementations
+ * of units that are aware of registered providers.
+ *
+ * @param {number} numOfGuestInfoEntries The number of "GuestInfo" objects that will be returned by the provider.
+ */
+export function registerMockProvider(numOfGuestInfoEntries = 1) {
+  ProviderRegistry.register(
+    ProviderKey.useGuestBookInfo,
+    useGuestBookInfoMockProvider(numOfGuestInfoEntries)
+  );
 }


### PR DESCRIPTION
This commit introduces the ProviderRegistry class which can be used to inject dependencies into workflows for testing.