### PR TITLE
Update @typescript-eslint Plugin

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,9 +23,11 @@ overrides:
           "eslint:recommended",
           "plugin:react/all",
           "plugin:react-hooks/recommended",
-          "plugin:@typescript-eslint/recommended",
+          "plugin:@typescript-eslint/recommended-type-checked",
         ],
+      "parserOptions": { "project": ["./tsconfig.json"] },
       "rules": {
+          "@typescript-eslint/explicit-function-return-type": "error",
           "react/jsx-filename-extension": ["error", { "extensions": [".tsx"] }],
           # Style rule, unneeded with Prettier
           "react/jsx-indent": "off",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
-    "@typescript-eslint/eslint-plugin": "^5.57.0",
-    "@typescript-eslint/parser": "^5.57.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1",
     "eslint": "^8.38.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,7 +11,7 @@ import React from "react";
  *
  * @return {ReactElement} React Component
  */
-function App() {
+function App(): JSX.Element {
   const { width, height } = useWindowDimensions();
   return (
     <div

--- a/src/app/AppAcknowledgements.tsx
+++ b/src/app/AppAcknowledgements.tsx
@@ -6,7 +6,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function AppAcknowledgements() {
+export default function AppAcknowledgements(): JSX.Element {
   const period = ".";
 
   return (

--- a/src/app/AppBody.tsx
+++ b/src/app/AppBody.tsx
@@ -7,7 +7,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function AppBody() {
+export default function AppBody(): JSX.Element {
   return (
     <div style={{ display: "flex", width: "100%" }}>
       <div style={{ display: "flex", flex: 1 }}>

--- a/src/app/AppLinks.tsx
+++ b/src/app/AppLinks.tsx
@@ -6,7 +6,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function AppLinks() {
+export default function AppLinks(): JSX.Element {
   const linksHdr = "Links";
 
   return (

--- a/src/app/AppTitle.tsx
+++ b/src/app/AppTitle.tsx
@@ -8,7 +8,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function AppTitle() {
+export default function AppTitle(): JSX.Element {
   const title = "Austin's React Website";
 
   return (

--- a/src/app/AppWidgets.tsx
+++ b/src/app/AppWidgets.tsx
@@ -7,7 +7,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function AppWidgets() {
+export default function AppWidgets(): JSX.Element {
   return (
     <div
       style={{

--- a/src/component/Link.tsx
+++ b/src/component/Link.tsx
@@ -6,7 +6,7 @@ import React from "react";
  * @param {LinkProps} props Properties.
  * @return {ReactElement} The link component.
  */
-export default function Link({ description, url }: LinkProps) {
+export default function Link({ description, url }: LinkProps): JSX.Element {
   return (
     <a className="App-link" href={url}>
       {description}

--- a/src/component/portfoliolink/PortfolioLink.tsx
+++ b/src/component/portfoliolink/PortfolioLink.tsx
@@ -15,7 +15,7 @@ export default function PortfolioLink({
   urlId,
   issuerDescription,
   issuerUrl,
-}: PortfolioLinkProps) {
+}: PortfolioLinkProps): JSX.Element {
   if (issuerDescription && issuerUrl) {
     return (
       <PortfolioLinkWithIssuer

--- a/src/component/portfoliolink/PortfolioLinkWithIssuer.tsx
+++ b/src/component/portfoliolink/PortfolioLinkWithIssuer.tsx
@@ -12,7 +12,7 @@ export default function PortfolioLinkWithoutIssuer({
   description,
   urlId,
   url,
-}: PortfolioLinkProps) {
+}: PortfolioLinkProps): JSX.Element {
   return (
     <div className="App-text">
       <div>{description}</div>

--- a/src/component/portfoliolink/PortfolioLinkWithoutIssuer.tsx
+++ b/src/component/portfoliolink/PortfolioLinkWithoutIssuer.tsx
@@ -14,7 +14,7 @@ export default function PortfolioLinkWithIssuer({
   urlId,
   issuerDescription = "",
   issuerUrl = "",
-}: PortfolioLinkProps) {
+}: PortfolioLinkProps): JSX.Element {
   return (
     <div className="App-text">
       <div>{description}</div>

--- a/src/component/widget/count/Counter.tsx
+++ b/src/component/widget/count/Counter.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from "react";
  *
  * @return {ReactElement}
  */
-export default function Counter() {
+export default function Counter(): JSX.Element {
   const [count, setCount] = React.useState(0);
   const onClick = useCallback(() => {
     setCount(count + 1);

--- a/src/component/widget/guestBook/GuestBook.tsx
+++ b/src/component/widget/guestBook/GuestBook.tsx
@@ -1,7 +1,7 @@
 import { GuestInfo } from "../../../hook/guests/guestBookInfo";
 import useGuestBookInfo from "../../../hook/guests/useGuestBookInfo";
 import GuestEntry, { guestEntryGap } from "./GuestEntry";
-import React, { ReactNode } from "react";
+import React from "react";
 
 /**
  * Create a list of GuestEntry components that will be in the GuestBook.
@@ -9,8 +9,8 @@ import React, { ReactNode } from "react";
  * @param {GuestInfo[]} guests The information for each guest.
  * @return {ReactNode[]}
  */
-function createGuestEntries(guests: GuestInfo[]): ReactNode[] {
-  const allGuestEntries: ReactNode[] = [];
+function createGuestEntries(guests: GuestInfo[]): JSX.Element[] {
+  const allGuestEntries: JSX.Element[] = [];
   const lastGuestIndex = guests.length - 1;
 
   for (let guestIndex = 0; guestIndex < guests.length; guestIndex++) {
@@ -36,7 +36,7 @@ function createGuestEntries(guests: GuestInfo[]): ReactNode[] {
  *
  * @return {ReactElement}
  */
-export default function GuestBook() {
+export default function GuestBook(): JSX.Element {
   const { guests } = useGuestBookInfo();
 
   // TODO: Add a button to "sign my guest book"

--- a/src/component/widget/guestBook/GuestEntry.tsx
+++ b/src/component/widget/guestBook/GuestEntry.tsx
@@ -10,7 +10,7 @@ export const guestEntryGap = 3;
  * @param {GuestEntryProps} guestEntry The properties/data of a single guest.
  * @return {GuestEntry}
  */
-export default function GuestEntry(guestEntry: GuestEntryProps) {
+export default function GuestEntry(guestEntry: GuestEntryProps): JSX.Element {
   const { name, website, message, visitDate, isFirst, isLast } = guestEntry;
 
   const bRadius = 15;

--- a/src/component/widget/statistic/HiddenStats.tsx
+++ b/src/component/widget/statistic/HiddenStats.tsx
@@ -8,7 +8,7 @@ import React from "react";
  *
  * @return {ReactElement} React Component
  */
-export default function Stats({ onClick }: HiddenStatsProps) {
+export default function Stats({ onClick }: HiddenStatsProps): JSX.Element {
   const leftArrow = "◀";
   return (
     <div className="Stats Stats-Container disable-text-selection">

--- a/src/component/widget/statistic/Stats.tsx
+++ b/src/component/widget/statistic/Stats.tsx
@@ -8,7 +8,7 @@ import React, { useCallback } from "react";
  *
  * @return {ReactElement} React Component
  */
-export default function Stats() {
+export default function Stats(): JSX.Element {
   const [showResults, setShowResults] = React.useState(true);
   const onClick = useCallback(() => {
     setShowResults(!showResults);

--- a/src/component/widget/statistic/WindowSize.tsx
+++ b/src/component/widget/statistic/WindowSize.tsx
@@ -6,7 +6,7 @@ import React from "react";
  *
  * @return {ReactElement} React Component
  */
-export default function WindowSize() {
+export default function WindowSize(): JSX.Element {
   const { width, height } = useWindowDimensions();
   const title = "Window Size";
   const fontSize = Math.max(10, width / 130);

--- a/src/hook/dimension/__tests__/TestComponentUseWindowDimension.tsx
+++ b/src/hook/dimension/__tests__/TestComponentUseWindowDimension.tsx
@@ -6,7 +6,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function TestComponentUseWindowDimension() {
+export default function TestComponentUseWindowDimension(): JSX.Element {
   const { height, width } = useWindowDimensions();
 
   return <div>{"width: " + width + " / height: " + height}</div>;

--- a/src/hook/dimension/useWindowDimensions.ts
+++ b/src/hook/dimension/useWindowDimensions.ts
@@ -22,7 +22,7 @@ const useWindowDimensions = (): WindowDimensions => {
     height: 0,
   });
 
-  const handleResize = () => {
+  const handleResize: () => void = () => {
     setWindowDimensions(getWindowDimensions());
   };
 

--- a/src/hook/guests/__tests__/TestComponentUseGuestBookInfo.tsx
+++ b/src/hook/guests/__tests__/TestComponentUseGuestBookInfo.tsx
@@ -6,7 +6,7 @@ import React from "react";
  *
  * @return {ReactElement}
  */
-export default function TestComponentUseWindowDimension() {
+export default function TestComponentUseWindowDimension(): JSX.Element {
   const { guests } = useGuestBookInfo();
 
   return (

--- a/src/hook/guests/retrieveGuestBookInfo.ts
+++ b/src/hook/guests/retrieveGuestBookInfo.ts
@@ -25,6 +25,11 @@ const retrieveGuestBookInfo = (): Promise<GuestBookInfo> => {
     )
     .then((v): GuestBookInfo => {
       return {
+        // We can't provide a type for the object coming in here, so we need to
+        //  disable some of the unsafe/'any' rules. But the whole purpose of this
+        //  function is to structure the unknown object into a type object, so
+        //  we're isolating and minimizing the impact here.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         guests: v.data.guests.map((gi: ExpectedFields) => {
           return {
             name: gi[_1],

--- a/src/hook/guests/useGuestBookInfo.ts
+++ b/src/hook/guests/useGuestBookInfo.ts
@@ -19,7 +19,10 @@ const useGuestBookInfo = (): GuestBookInfo => {
   );
 
   useEffect(() => {
-    provider().then((d) => setGuestBookInfo(d));
+    provider().then(
+      (d) => setGuestBookInfo(d),
+      () => {}
+    );
   }, [provider]);
 
   return guestBookInfo;

--- a/src/hook/provide/ProviderRegistry.ts
+++ b/src/hook/provide/ProviderRegistry.ts
@@ -21,7 +21,10 @@ export default abstract class ProviderRegistry {
    * @param {ProviderKey} providerKey The unique key of the provider that is being registered/injected.
    * @param {Provider} providerImpl The actual implementation that is to be injected.
    */
-  public static register(providerKey: ProviderKey, providerImpl: Provider) {
+  public static register(
+    providerKey: ProviderKey,
+    providerImpl: Provider
+  ): void {
     ProviderRegistry.registry.set(providerKey, providerImpl);
   }
 

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,14 +1,19 @@
 import { ReportHandler } from "web-vitals";
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+const reportWebVitals: (onPerfEntry?: ReportHandler) => void = (
+  onPerfEntry?: ReportHandler
+) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+    import("web-vitals").then(
+      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+        getCLS(onPerfEntry);
+        getFID(onPerfEntry);
+        getFCP(onPerfEntry);
+        getLCP(onPerfEntry);
+        getTTFB(onPerfEntry);
+      },
+      () => {}
+    );
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,14 +1304,14 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz#2cbcf822bf3764c9658c4d2e568bd0c0cb748016"
   integrity sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.6.1":
+"@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
   integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
@@ -2300,7 +2300,7 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.12", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -2407,6 +2407,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.5.tgz#deed5ab7019756c9c90ea86139106b0346223f35"
   integrity sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==
 
+"@types/semver@^7.5.0":
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
+
 "@types/send@*":
   version "0.17.4"
   resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.4.tgz#6619cd24e7270793702e4e6a4b958a9010cfc57a"
@@ -2486,7 +2491,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.5.0", "@typescript-eslint/eslint-plugin@^5.57.0":
+"@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
   integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
@@ -2502,6 +2507,23 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/eslint-plugin@^6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz#f98bd887bf95551203c917e734d113bf8d527a0c"
+  integrity sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==
+  dependencies:
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "6.13.1"
+    "@typescript-eslint/type-utils" "6.13.1"
+    "@typescript-eslint/utils" "6.13.1"
+    "@typescript-eslint/visitor-keys" "6.13.1"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/experimental-utils@^5.0.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.62.0.tgz#14559bf73383a308026b427a4a6129bae2146741"
@@ -2509,7 +2531,7 @@
   dependencies:
     "@typescript-eslint/utils" "5.62.0"
 
-"@typescript-eslint/parser@^5.5.0", "@typescript-eslint/parser@^5.57.0":
+"@typescript-eslint/parser@^5.5.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
   integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
@@ -2519,6 +2541,17 @@
     "@typescript-eslint/typescript-estree" "5.62.0"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@^6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.13.1.tgz#29d6d4e5fab4669e58bc15f6904b67da65567487"
+  integrity sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==
+  dependencies:
+    "@typescript-eslint/scope-manager" "6.13.1"
+    "@typescript-eslint/types" "6.13.1"
+    "@typescript-eslint/typescript-estree" "6.13.1"
+    "@typescript-eslint/visitor-keys" "6.13.1"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
@@ -2526,6 +2559,14 @@
   dependencies:
     "@typescript-eslint/types" "5.62.0"
     "@typescript-eslint/visitor-keys" "5.62.0"
+
+"@typescript-eslint/scope-manager@6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz#58c7c37c6a957d3d9f59bc4f64c2888e0cac1d70"
+  integrity sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.13.1"
+    "@typescript-eslint/visitor-keys" "6.13.1"
 
 "@typescript-eslint/type-utils@5.62.0":
   version "5.62.0"
@@ -2537,10 +2578,25 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/type-utils@6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz#e6e5885e387841cae9c38fc0638fd8b7561973d6"
+  integrity sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "6.13.1"
+    "@typescript-eslint/utils" "6.13.1"
+    debug "^4.3.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/types@5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
   integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
+
+"@typescript-eslint/types@6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.13.1.tgz#b56f26130e7eb8fa1e429c75fb969cae6ad7bb5c"
+  integrity sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==
 
 "@typescript-eslint/typescript-estree@5.62.0":
   version "5.62.0"
@@ -2554,6 +2610,19 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz#d01dda78d2487434d1c503853fa00291c566efa4"
+  integrity sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.13.1"
+    "@typescript-eslint/visitor-keys" "6.13.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
 "@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.58.0":
   version "5.62.0"
@@ -2569,6 +2638,19 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.13.1.tgz#925b3a2453a71ada914ae329b7bb7e7d96634b2f"
+  integrity sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.13.1"
+    "@typescript-eslint/types" "6.13.1"
+    "@typescript-eslint/typescript-estree" "6.13.1"
+    semver "^7.5.4"
+
 "@typescript-eslint/visitor-keys@5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
@@ -2576,6 +2658,14 @@
   dependencies:
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@6.13.1":
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz#c4b692dcc23a4fc60685b718f10fde789d65a540"
+  integrity sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==
+  dependencies:
+    "@typescript-eslint/types" "6.13.1"
+    eslint-visitor-keys "^3.4.1"
 
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
@@ -5665,6 +5755,11 @@ ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
+ignore@^5.2.4:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
+  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
 
 immer@^9.0.7:
   version "9.0.21"
@@ -9878,6 +9973,11 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-api-utils@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"


### PR DESCRIPTION
This commit updates the @typescript-eslint plugin to a newer version but also now uses the recommended-type-checked configuration: https://typescript-eslint.io/linting/configs/#recommended-type-checked

This commit also adds the explicit return type rule for functions: https://typescript-eslint.io/rules/explicit-function-return-type/