### PR TITLE
Update Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,3 @@
 {
-  "endOfLine": "auto",
-  "order": "alphabetical"
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "postcss": "^8.4.31",
-    "prettier": "^2.8.7",
-    "prettier-plugin-css-order": "^1.3.0",
+    "prettier": "^3.1.0",
+    "prettier-plugin-css-order": "^2.0.1",
     "react-test-renderer": "^18.2.0",
     "ts-jest": "^29.0.5"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/src/component/portfoliolink/__tests__/PortfolioLink-test.js
+++ b/src/component/portfoliolink/__tests__/PortfolioLink-test.js
@@ -8,7 +8,7 @@ it("renders to match snapshot", () => {
         description="description Field"
         url="https://example.com"
         urlId="linkId Field"
-      />
+      />,
     )
     .toJSON();
 

--- a/src/component/portfoliolink/__tests__/PortfolioLinkWithIssuer-test.js
+++ b/src/component/portfoliolink/__tests__/PortfolioLinkWithIssuer-test.js
@@ -10,7 +10,7 @@ it("renders to match snapshot", () => {
         urlId="linkId Field"
         issuerDescription="issuer description field"
         issuerUrl="https://https://github.com/atb-brown"
-      />
+      />,
     )
     .toJSON();
 

--- a/src/component/portfoliolink/__tests__/PortfolioLinkWithoutIssuer-test.js
+++ b/src/component/portfoliolink/__tests__/PortfolioLinkWithoutIssuer-test.js
@@ -8,7 +8,7 @@ it("renders to match snapshot", () => {
         description="description Field"
         url="https://example.com"
         urlId="linkId Field"
-      />
+      />,
     )
     .toJSON();
 

--- a/src/component/widget/guestBook/GuestBook.tsx
+++ b/src/component/widget/guestBook/GuestBook.tsx
@@ -24,7 +24,7 @@ function createGuestEntries(guests: GuestInfo[]): JSX.Element[] {
         name={guestInfo?.name}
         visitDate={guestInfo?.visitDate}
         website={guestInfo?.website}
-      />
+      />,
     );
   }
 

--- a/src/component/widget/guestBook/__tests__/GuestEntry-test.js
+++ b/src/component/widget/guestBook/__tests__/GuestEntry-test.js
@@ -11,7 +11,7 @@ it("renders to match snapshot", () => {
       website="https://atb-brown.github.io/austin/"
       isFirst={true}
       isLast={true}
-    />
+    />,
   );
 
   expect(tree).toMatchSnapshot();
@@ -26,7 +26,7 @@ it("top row entry", () => {
       website="https://atb-brown.github.io/austin/"
       isFirst={true}
       isLast={false}
-    />
+    />,
   );
 
   expect(tree).toMatchSnapshot();
@@ -41,7 +41,7 @@ it("bottom row entry", () => {
       website="https://atb-brown.github.io/austin/"
       isFirst={false}
       isLast={true}
-    />
+    />,
   );
 
   expect(tree).toMatchSnapshot();

--- a/src/hook/dimension/__tests__/useWindowDimensions-test.js
+++ b/src/hook/dimension/__tests__/useWindowDimensions-test.js
@@ -5,7 +5,7 @@ it("Test window width and height.", () => {
   // Set the size
   setScreenSize(1000, 800);
   const initialFragment = render(
-    <TestComponentUseWindowDimension />
+    <TestComponentUseWindowDimension />,
   ).asFragment;
 
   expect(initialFragment()).toMatchSnapshot();
@@ -13,7 +13,7 @@ it("Test window width and height.", () => {
   // Set a new size and re-render
   setScreenSize(500, 400);
   const reRenderedFragment = render(
-    <TestComponentUseWindowDimension />
+    <TestComponentUseWindowDimension />,
   ).asFragment;
 
   expect(reRenderedFragment()).toMatchSnapshot();

--- a/src/hook/guests/__tests__/retrieveGuestBookInfo-test.js
+++ b/src/hook/guests/__tests__/retrieveGuestBookInfo-test.js
@@ -12,7 +12,7 @@ it("Get Guest Book", async () => {
   const austin = response.guests[0];
   expect(austin.name).toBe("Austin Brown");
   expect(austin.message).toBe(
-    "You can leave a message if you want. You can also leave your website for self-promotion, if you'd like!"
+    "You can leave a message if you want. You can also leave your website for self-promotion, if you'd like!",
   );
   expect(austin.visitDate).toBe("2023-11-15");
   expect(austin.website).toBe("https://atb-brown.github.io/austin/");

--- a/src/hook/guests/retrieveGuestBookInfo.ts
+++ b/src/hook/guests/retrieveGuestBookInfo.ts
@@ -21,7 +21,7 @@ type ExpectedFields = {
 const retrieveGuestBookInfo = (): Promise<GuestBookInfo> => {
   return axios
     .get(
-      "https://raw.githubusercontent.com/atb-brown/guest-book/main/guests.json"
+      "https://raw.githubusercontent.com/atb-brown/guest-book/main/guests.json",
     )
     .then((v): GuestBookInfo => {
       return {

--- a/src/hook/guests/useGuestBookInfo.ts
+++ b/src/hook/guests/useGuestBookInfo.ts
@@ -15,13 +15,13 @@ const useGuestBookInfo = (): GuestBookInfo => {
 
   const provider = Providers.get<() => Promise<GuestBookInfo>>(
     ProviderKey.useGuestBookInfo,
-    retrieveGuestBookInfo
+    retrieveGuestBookInfo,
   );
 
   useEffect(() => {
     provider().then(
       (d) => setGuestBookInfo(d),
-      () => {}
+      () => {},
     );
   }, [provider]);
 

--- a/src/hook/provide/ProviderRegistry.ts
+++ b/src/hook/provide/ProviderRegistry.ts
@@ -23,7 +23,7 @@ export default abstract class ProviderRegistry {
    */
   public static register(
     providerKey: ProviderKey,
-    providerImpl: Provider
+    providerImpl: Provider,
   ): void {
     ProviderRegistry.registry.set(providerKey, providerImpl);
   }
@@ -38,7 +38,7 @@ export default abstract class ProviderRegistry {
    */
   public static get<Provider>(
     providerKey: ProviderKey,
-    realProvider: Provider
+    realProvider: Provider,
   ): Provider {
     return (
       ProviderRegistry.registry.has(providerKey)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,12 +5,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
+  document.getElementById("root") as HTMLElement,
 );
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,7 +1,7 @@
 import { ReportHandler } from "web-vitals";
 
 const reportWebVitals: (onPerfEntry?: ReportHandler) => void = (
-  onPerfEntry?: ReportHandler
+  onPerfEntry?: ReportHandler,
 ) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import("web-vitals").then(
@@ -12,7 +12,7 @@ const reportWebVitals: (onPerfEntry?: ReportHandler) => void = (
         getLCP(onPerfEntry);
         getTTFB(onPerfEntry);
       },
-      () => {}
+      () => {},
     );
   }
 };

--- a/src/test/mock/hook/mockUseGuestBookInfo.js
+++ b/src/test/mock/hook/mockUseGuestBookInfo.js
@@ -43,6 +43,6 @@ function useGuestBookInfoMockProvider(numOfGuestInfoEntries = 1) {
 export function registerMockProvider(numOfGuestInfoEntries = 1) {
   ProviderRegistry.register(
     ProviderKey.useGuestBookInfo,
-    useGuestBookInfoMockProvider(numOfGuestInfoEntries)
+    useGuestBookInfoMockProvider(numOfGuestInfoEntries),
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,7 +3892,7 @@ css-declaration-sorter@^6.3.1:
   resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz#28beac7c20bad7f1775be3a7129d7eae409a3a71"
   integrity sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==
 
-css-declaration-sorter@^7.0.0:
+css-declaration-sorter@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-7.1.1.tgz#9796bcc257b4647c39993bda8d431ce32b666f80"
   integrity sha512-dZ3bVTEEc1vxr3Bek9vGwfB5Z6ESPULhcRvO472mfjVnj8jRcTnKO8/JTczlvxM10Myb+wBM++1MtdO76eWcaQ==
@@ -8557,20 +8557,19 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-css-order@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-css-order/-/prettier-plugin-css-order-1.3.1.tgz#4e942b3c564b0837415f258b5fc8cfc612495857"
-  integrity sha512-c8rtt5MLDDoMvutJHXT5t/bKO/bbHHnRI/UKzGGqKyskoHXpDn58SiNNW7ot2eCBFh5iLSy+0nUYArfvFWs57A==
+prettier-plugin-css-order@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-css-order/-/prettier-plugin-css-order-2.0.1.tgz#fa9abb5e879ccf2fef5d2d7822ead15b8c75c2fc"
+  integrity sha512-Y+wZ0wI7/qFUritirJksQn13KqbcNC3OZXSxGh1ui/X39hAeMW9md+Mp7fjk8H4ZQQ8c5CTYZxShoBfAal/79A==
   dependencies:
-    css-declaration-sorter "^7.0.0"
+    css-declaration-sorter "^7.1.1"
     postcss-less "^6.0.0"
     postcss-scss "^4.0.3"
-    sync-threads "^1.0.1"
 
-prettier@^2.8.7:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
+  integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
@@ -9783,11 +9782,6 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
-sync-threads@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sync-threads/-/sync-threads-1.0.1.tgz#1e854ce579eaca0d0f1f0885a40bc2be6237b593"
-  integrity sha512-hIdwt/c/e1ONnr2RJmfBxEAj/J6KQQWKdToF3Qw8ZNRsTNNteGkOe63rQy9I7J5UNlr8Yl0wkzIr9wgLY94x0Q==
 
 tailwindcss@^3.0.2:
   version "3.3.5"


### PR DESCRIPTION
Update prettier to the most recent version: 3.1.0

Also updates the prettier-plugin-css-order to 2.0.1