### PR TITLE
Introduce ProdMode Functionality

### DIFF
--- a/src/hook/prod/ProdMode.tsx
+++ b/src/hook/prod/ProdMode.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import useProdMode from "./useProdMode";
+
+/**
+ * This component registers that the project is running in production mode.
+ *
+ * @return {ReactElement} React Component
+ */
+export default function ProdMode(): JSX.Element {
+  useProdMode();
+  return <div />;
+}

--- a/src/hook/prod/__tests__/useProdMode-test.js
+++ b/src/hook/prod/__tests__/useProdMode-test.js
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { failInProd } from "../useProdMode";
+import ProdMode from "../ProdMode";
+import { mockProd, unmockProd } from "../../../test/mock/hook/mockUseProdMode";
+
+// This function should fail if executed in production mode.
+const shouldFailInProd = () => {
+  failInProd("Test Error");
+  return "SUCCESS";
+};
+
+it("Fail When ProdMode Enabled", async () => {
+  mockProd();
+
+  render(<ProdMode />);
+  expect(shouldFailInProd).toThrow(Error);
+  expect(shouldFailInProd).toThrow("Test Error");
+
+  unmockProd();
+});
+
+it("Succeed When ProdMode Not Enabled", async () => {
+  expect(shouldFailInProd()).toBe("SUCCESS");
+});

--- a/src/hook/prod/useProdMode.ts
+++ b/src/hook/prod/useProdMode.ts
@@ -1,0 +1,42 @@
+let prodMode: boolean = false;
+
+/**
+ * This hook will allow components to access information from the guest book.
+ *
+ * @return {void}
+ */
+const useProdMode: () => void = (): void => {
+  prodMode = true;
+};
+/**
+ * This function can be used to make a particular process "fail" if invoked in
+ * production. This is useful if there is any functionality that has been
+ * written specifically for testing but should not be allowed to be used when
+ * in the "production" build/execution of the site.
+ *
+ * @param {string} processDescription A description of the process that will
+ *                  fail if invoked in prod.
+ */
+export function failInProd(processDescription: string): void {
+  if (new ProdChecker().isProdMode()) {
+    throw Error(`You cannot ${processDescription} in prod mode.`);
+  }
+}
+
+/**
+ * A class that wraps around our implementation that determines whether or not
+ * the app is running in production mode. This is handled in a class method
+ * so that we can mock this for testing.
+ */
+export class ProdChecker {
+  /**
+   * Determine if the application is running in production mode.
+   *
+   * @return {boolean}
+   */
+  isProdMode(): boolean {
+    return prodMode;
+  }
+}
+
+export default useProdMode;

--- a/src/hook/provide/ProviderRegistry.ts
+++ b/src/hook/provide/ProviderRegistry.ts
@@ -1,3 +1,5 @@
+import { failInProd } from "../prod/useProdMode";
+
 type Provider = () => unknown;
 
 const registry: Map<ProviderKey, Provider> = new Map();
@@ -9,8 +11,6 @@ const registry: Map<ProviderKey, Provider> = new Map();
  * This function should NOT be used/called in any deployed code; this should
  * only be used for testing.
  *
- * TODO: Create an eslint rule to ensure this is not called in deployed code. https://eslint.org/docs/latest/extend/custom-rule-tutorial
- *
  * @param {ProviderKey} providerKey The unique key of the provider that is
  * being registered/injected.
  * @param {Provider} providerImpl The actual implementation that is to be
@@ -20,6 +20,7 @@ export function register(
   providerKey: ProviderKey,
   providerImpl: Provider,
 ): void {
+  failInProd("inject a provider implementation");
   registry.set(providerKey, providerImpl);
 }
 

--- a/src/hook/provide/__tests__/ProviderRegistry-test.js
+++ b/src/hook/provide/__tests__/ProviderRegistry-test.js
@@ -1,3 +1,4 @@
+import { mockProd, unmockProd } from "../../../test/mock/hook/mockUseProdMode";
 import { get, register } from "../ProviderRegistry";
 
 const mocked = "mocked";
@@ -15,4 +16,16 @@ it("Alternative Provider Is Registered", () => {
   register(fakeProviderKey, () => mocked);
   const provider = get(fakeProviderKey, realProviderImpl);
   expect(provider()).toBe(mocked);
+});
+
+it("Fails in ProdMode", () => {
+  mockProd();
+
+  const failingFunctionCall = () => register(fakeProviderKey, () => mocked);
+  expect(failingFunctionCall).toThrow(Error);
+  expect(failingFunctionCall).toThrow(
+    "You cannot inject a provider implementation in prod mode.",
+  );
+
+  unmockProd();
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import App from "./app/App";
+import ProdMode from "./hook/prod/ProdMode";
 import "./index.css";
 import reportWebVitals from "./reportWebVitals";
 import React from "react";
@@ -9,6 +10,7 @@ const root: ReactDOM.Root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
+    <ProdMode />
     <App />
   </React.StrictMode>,
 );

--- a/src/test/mock/hook/mockUseProdMode.js
+++ b/src/test/mock/hook/mockUseProdMode.js
@@ -1,0 +1,20 @@
+import { ProdChecker } from "../../../hook/prod/useProdMode";
+import { jest } from "@jest/globals";
+
+const mockIsProdMode = jest.spyOn(ProdChecker.prototype, "isProdMode");
+
+/**
+ * Enable mocked production mode.
+ */
+export function mockProd() {
+  mockIsProdMode.mockImplementation(() => {
+    return true;
+  });
+}
+
+/**
+ * Disable mocked production mode.
+ */
+export function unmockProd() {
+  mockIsProdMode.mockReset();
+}


### PR DESCRIPTION
This commit introduces the useProdMode hook which is used when the app is built to signify that the application is being ran in production mode; in production mode, some logic (such as dependency injection via the ProviderRegistry) should not be allowed, so the new ProMode also provides a function that disallowed modules can use that will fail if provoked in production.