### PR TITLE
Remember Click Count in Cookie

### DIFF
--- a/src/app/__tests__/__snapshots__/App-test.js.snap
+++ b/src/app/__tests__/__snapshots__/App-test.js.snap
@@ -201,7 +201,7 @@ exports[`renders to match snapshot 1`] = `
                 class="disable-text-selection clickable"
                 data-testid="counter"
                 style="align-items: center; border-radius: 10px; display: flex; font-size: 20px; height: 60px; justify-content: center; width: 25%;"
-                title="This component counts the number of times it has been clicked. It's an exercise in handling clicks and component state!"
+                title="This component counts the number of times it has been clicked. It's an exercise in handling clicks, component state, and cookie management!"
               >
                 0
               </div>

--- a/src/app/__tests__/__snapshots__/AppBody-test.js.snap
+++ b/src/app/__tests__/__snapshots__/AppBody-test.js.snap
@@ -139,7 +139,7 @@ exports[`renders to match snapshot 1`] = `
             class="disable-text-selection clickable"
             data-testid="counter"
             style="align-items: center; border-radius: 10px; display: flex; font-size: 20px; height: 60px; justify-content: center; width: 25%;"
-            title="This component counts the number of times it has been clicked. It's an exercise in handling clicks and component state!"
+            title="This component counts the number of times it has been clicked. It's an exercise in handling clicks, component state, and cookie management!"
           >
             0
           </div>

--- a/src/app/__tests__/__snapshots__/AppWidgets-test.js.snap
+++ b/src/app/__tests__/__snapshots__/AppWidgets-test.js.snap
@@ -20,7 +20,7 @@ exports[`renders to match snapshot 1`] = `
         class="disable-text-selection clickable"
         data-testid="counter"
         style="align-items: center; border-radius: 10px; display: flex; font-size: 20px; height: 60px; justify-content: center; width: 25%;"
-        title="This component counts the number of times it has been clicked. It's an exercise in handling clicks and component state!"
+        title="This component counts the number of times it has been clicked. It's an exercise in handling clicks, component state, and cookie management!"
       >
         0
       </div>

--- a/src/component/widget/cookie/RememberMe.tsx
+++ b/src/component/widget/cookie/RememberMe.tsx
@@ -37,6 +37,7 @@ export default function RememberMe(): JSX.Element {
       if (!remember) {
         setCookie(Cookies.Remembered, "true");
       } else {
+        // TODO: Need to iterate and remove all cookies.
         removeCookie(Cookies.Remembered);
       }
     }

--- a/src/component/widget/count/Counter.tsx
+++ b/src/component/widget/count/Counter.tsx
@@ -1,20 +1,39 @@
+import { useCookies } from "react-cookie";
 import "../../../common.css";
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
+import { Cookies } from "../../../hook/cookie/Cookies";
+
+const title =
+  "This component counts the number of times it has been clicked. It's an" +
+  " exercise in handling clicks, component state, and cookie management!";
 
 /**
  * This button is counts the number of times the user clicks it.
  *
- * @return {ReactElement}
+ * @return {JSX.Element}
  */
 export default function Counter(): JSX.Element {
-  const [count, setCount] = React.useState(0);
+  const [cookies, setCookie, removeCookie] = useCookies([
+    Cookies.Remembered,
+    Cookies.Count,
+  ]);
+  const [count, setCount] = React.useState(
+    Object.hasOwn(cookies, Cookies.Count)
+      ? (cookies[Cookies.Count] as number)
+      : 0,
+  );
+
   const onClick: () => void = useCallback(() => {
     setCount(count + 1);
   }, [count, setCount]);
 
-  const title =
-    "This component counts the number of times it has been clicked. It's an" +
-    " exercise in handling clicks and component state!";
+  useEffect(() => {
+    if (Object.hasOwn(cookies, Cookies.Remembered)) {
+      setCookie(Cookies.Count, count);
+    } else {
+      removeCookie(Cookies.Count);
+    }
+  }, [count, cookies, setCookie, removeCookie]);
 
   return (
     <div

--- a/src/component/widget/count/__tests__/Counter-test.js
+++ b/src/component/widget/count/__tests__/Counter-test.js
@@ -1,15 +1,32 @@
 import Counter from "../Counter";
 import "@testing-library/jest-dom";
 import { screen, render, fireEvent } from "@testing-library/react";
-import renderer from "react-test-renderer";
+import { Cookies as ReactCookies } from "react-cookie";
+import { Cookies } from "../../../../hook/cookie/Cookies";
 
-it("renders to match snapshot", () => {
-  const tree = renderer.create(<Counter />);
+const cookies = new ReactCookies();
 
-  expect(tree).toMatchSnapshot();
+it("renders to match snapshot without cookie", () => {
+  const renderResult = render(<Counter />);
+
+  expect(renderResult.asFragment()).toMatchSnapshot();
 });
 
-it("click toggles the ribbon", () => {
+it("renders to match snapshot with cookie", async () => {
+  cookies.set(Cookies.Count, 12);
+
+  const renderResult = render(<Counter />);
+
+  const counterComp = screen.getByTestId("counter");
+  expect(counterComp).toBeDefined();
+  expect(counterComp).toHaveTextContent("12");
+
+  expect(renderResult.asFragment()).toMatchSnapshot();
+
+  cookies.remove(Cookies.Count);
+});
+
+it("click increases the count", () => {
   render(<Counter />);
 
   const counterComp = screen.getByTestId("counter");
@@ -27,4 +44,18 @@ it("click toggles the ribbon", () => {
   fireEvent.click(counterComp);
   fireEvent.click(counterComp);
   expect(counterComp).toHaveTextContent("4");
+});
+
+it("click increases the count in the cookie when user is remembered", () => {
+  cookies.set(Cookies.Remembered, true);
+  cookies.set(Cookies.Count, 12);
+  render(<Counter />);
+
+  const counterComp = screen.getByTestId("counter");
+  expect(counterComp).toBeDefined();
+
+  fireEvent.click(counterComp);
+  fireEvent.click(counterComp);
+  fireEvent.click(counterComp);
+  expect(cookies.get(Cookies.Count)).toBe(15);
 });

--- a/src/component/widget/count/__tests__/__snapshots__/Counter-test.js.snap
+++ b/src/component/widget/count/__tests__/__snapshots__/Counter-test.js.snap
@@ -1,23 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders to match snapshot 1`] = `
-<div
-  className="disable-text-selection clickable"
-  data-testid="counter"
-  onClick={[Function]}
-  style={
-    {
-      "alignItems": "center",
-      "borderRadius": 10,
-      "display": "flex",
-      "fontSize": 20,
-      "height": 60,
-      "justifyContent": "center",
-      "width": "25%",
-    }
-  }
-  title="This component counts the number of times it has been clicked. It's an exercise in handling clicks and component state!"
->
-  0
-</div>
+exports[`renders to match snapshot with cookie 1`] = `
+<DocumentFragment>
+  <div
+    class="disable-text-selection clickable"
+    data-testid="counter"
+    style="align-items: center; border-radius: 10px; display: flex; font-size: 20px; height: 60px; justify-content: center; width: 25%;"
+    title="This component counts the number of times it has been clicked. It's an exercise in handling clicks, component state, and cookie management!"
+  >
+    12
+  </div>
+</DocumentFragment>
+`;
+
+exports[`renders to match snapshot without cookie 1`] = `
+<DocumentFragment>
+  <div
+    class="disable-text-selection clickable"
+    data-testid="counter"
+    style="align-items: center; border-radius: 10px; display: flex; font-size: 20px; height: 60px; justify-content: center; width: 25%;"
+    title="This component counts the number of times it has been clicked. It's an exercise in handling clicks, component state, and cookie management!"
+  >
+    0
+  </div>
+</DocumentFragment>
 `;

--- a/src/hook/cookie/Cookies.ts
+++ b/src/hook/cookie/Cookies.ts
@@ -1,3 +1,4 @@
 export enum Cookies {
   Remembered = "remembered",
+  Count = "count",
 }


### PR DESCRIPTION
With this commit, if the user has chosen to be remembered, the site will remember their click count on the Counter widget via a cookie.