### PR TITLE
75: Iterate to Remove All Cookies

### DIFF
--- a/src/component/widget/cookie/RememberMe.tsx
+++ b/src/component/widget/cookie/RememberMe.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect } from "react";
 import { useCookies } from "react-cookie";
 import "../../../common.css";
-import { Cookies } from "../../../hook/cookie/Cookies";
+import {
+  Cookies,
+  forEach as forEachCookie,
+} from "../../../hook/cookie/Cookies";
 
 const clickMeToRemember = "Click me if you want me to remember you!";
 const clickMeToForget = "Welcome back! Click me if you want me to forget.";
@@ -21,7 +24,8 @@ const title =
  * @return {JSX.Element}
  */
 export default function RememberMe(): JSX.Element {
-  const [cookies, setCookie, removeCookie] = useCookies([Cookies.Remembered]);
+  const [cookies, setCookie] = useCookies([Cookies.Remembered]);
+  const removeCookie = useCookies(Object.keys(Cookies))[2];
   const [remember, setRemember] = React.useState(
     Object.hasOwn(cookies, Cookies.Remembered),
   );
@@ -37,8 +41,7 @@ export default function RememberMe(): JSX.Element {
       if (!remember) {
         setCookie(Cookies.Remembered, "true");
       } else {
-        // TODO: Need to iterate and remove all cookies.
-        removeCookie(Cookies.Remembered);
+        forEachCookie(removeCookie);
       }
     }
   }, [confirmTxt, removeCookie, remember, setCookie]);

--- a/src/component/widget/count/Counter.tsx
+++ b/src/component/widget/count/Counter.tsx
@@ -13,10 +13,7 @@ const title =
  * @return {JSX.Element}
  */
 export default function Counter(): JSX.Element {
-  const [cookies, setCookie, removeCookie] = useCookies([
-    Cookies.Remembered,
-    Cookies.Count,
-  ]);
+  const [cookies, setCookie] = useCookies([Cookies.Remembered, Cookies.Count]);
   const [count, setCount] = React.useState(
     Object.hasOwn(cookies, Cookies.Count)
       ? (cookies[Cookies.Count] as number)
@@ -30,10 +27,8 @@ export default function Counter(): JSX.Element {
   useEffect(() => {
     if (Object.hasOwn(cookies, Cookies.Remembered)) {
       setCookie(Cookies.Count, count);
-    } else {
-      removeCookie(Cookies.Count);
     }
-  }, [count, cookies, setCookie, removeCookie]);
+  }, [count, cookies, setCookie]);
 
   return (
     <div

--- a/src/hook/cookie/Cookies.ts
+++ b/src/hook/cookie/Cookies.ts
@@ -2,3 +2,15 @@ export enum Cookies {
   Remembered = "remembered",
   Count = "count",
 }
+
+/**
+ * Process something using each cookie value.
+ *
+ * @param {function(string):void} doThis The function that will be processed on
+ *  each cookie.
+ */
+export function forEach(doThis: (cookie: string) => void): void {
+  for (const cookie of Object.values(Cookies)) {
+    doThis(cookie);
+  }
+}

--- a/src/hook/cookie/__tests__/Cookies-test.js
+++ b/src/hook/cookie/__tests__/Cookies-test.js
@@ -1,0 +1,12 @@
+import { Cookies } from "../Cookies";
+
+it("forEachCookie processes every cookie", () => {
+  const myArray = [];
+  const addToMyArray = (s) => myArray.push(s);
+
+  for (const cookie of Object.values(Cookies)) {
+    addToMyArray(cookie);
+  }
+
+  expect(myArray).toEqual(Object.values(Cookies));
+});


### PR DESCRIPTION
This commit addresses #75 and introduces a function that can be used to iterate over all enumerated cookie; this function is used in the RememberMe module to remove all cookies when a user chooses to be forgotten.